### PR TITLE
Fix: Correct syntax error in createTicket function.

### DIFF
--- a/script.js
+++ b/script.js
@@ -221,8 +221,9 @@ function createTicket(text, colour, flag, id) {
         lock.style.display = "block";
     })
 
-
-
+} catch (e) {
+    console.error("Error in ticket creation/rendering:", e);
+}
 }
 function headerClick(e) {
     let header = e.currentTarget;
@@ -299,5 +300,3 @@ function editTask(e) {
         }
     }
 }
-
-


### PR DESCRIPTION
This commit fixes an "Uncaught SyntaxError: Missing catch or finally after try" that was introduced in a previous commit. The error was due to a missing `catch` block for the second `try` statement within the `createTicket` function in `script.js`.

A `catch (e) { console.error("Error in ticket creation/rendering:", e); }` has been added to properly handle potential errors during the DOM manipulation and localStorage operations for tickets.